### PR TITLE
Fix Request.request to handle parameters for GET requests (list/show)

### DIFF
--- a/lib/transferwise.rb
+++ b/lib/transferwise.rb
@@ -10,6 +10,11 @@ require "transferwise/version"
 # Oauth2 Authentication
 require "transferwise/oauth"
 
+# ActiveSupport extensions
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/string/inflections'
+
 # Resources
 require 'transferwise/transferwise_object'
 require 'transferwise/api_resource'

--- a/lib/transferwise/request.rb
+++ b/lib/transferwise/request.rb
@@ -10,14 +10,20 @@ module Transferwise
       request_opts = {
         url: url,
         method: method,
-        payload: params.to_json,
         headers: request_headers(access_token).update(headers)
       }
+
+      if method == :get
+        request_opts[:headers].update(params: params)
+      else
+        request_opts.update(payload: params.to_json)
+      end
+
       response = execute_request(request_opts)
       parse(response)
     end
 
-    private
+    # Private class methods
 
     def self.request_headers(access_token)
       {
@@ -25,6 +31,7 @@ module Transferwise
         'Content-Type' => 'application/json'
       }
     end
+    private_class_method :request_headers
 
     def self.execute_request(request_opts)
       begin
@@ -38,6 +45,7 @@ module Transferwise
       end
       response
     end
+    private_class_method :execute_request
 
     def self.parse(response)
       begin
@@ -47,6 +55,7 @@ module Transferwise
       end
       response
     end
+    private_class_method :parse
 
     def self.handle_error(e, request_opts)
       if e.is_a?(RestClient::ExceptionWithResponse) && e.response
@@ -55,6 +64,7 @@ module Transferwise
         handle_restclient_error(e, request_opts)
       end
     end
+    private_class_method :handle_error
 
     def self.handle_api_error(resp)
       error_obj = parse(resp).with_indifferent_access
@@ -65,6 +75,7 @@ module Transferwise
         raise Transferwise::TransferwiseError.new(error_params(error_message, resp, error_obj))
       end
     end
+    private_class_method :handle_api_error
 
     def self.handle_restclient_error(e, request_opts)
       connection_message = "Please check your internet connection and try again. "
@@ -81,6 +92,7 @@ module Transferwise
 
       raise Transferwise::APIConnectionError.new({message: "#{message} \n\n (Error: #{e.message})"})
     end
+    private_class_method :handle_restclient_error
 
     def self.handle_parse_error(rcode, rbody)
       Transferwise::ParseError.new({
@@ -89,6 +101,7 @@ module Transferwise
         http_body: rbody
       })
     end
+    private_class_method :handle_parse_error
 
     def self.error_params(error, resp, error_obj)
       {
@@ -99,5 +112,6 @@ module Transferwise
         http_headers: resp.headers
       }
     end
+    private_class_method :error_params
   end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,158 @@
+require 'spec_helper'
+
+describe Transferwise::Request do
+  describe '.api_url' do
+    subject(:api_url) { Transferwise::Request.api_url }
+
+    after do
+      Transferwise.remove_instance_variable :@api_base if Transferwise.instance_variable_defined? :@api_base
+    end
+
+    it { is_expected.to eq 'https://api.sandbox.transferwise.tech' }
+
+    context 'specifying a URL' do
+      subject(:api_url) { Transferwise::Request.api_url('/v1/foo/bar') }
+
+      it { is_expected.to eq 'https://api.sandbox.transferwise.tech/v1/foo/bar' }
+    end
+
+    context 'live mode' do
+      before { expect(Transferwise).to receive(:mode).and_return 'live' }
+
+      it { is_expected.to eq 'https://api.transferwise.com' }
+    end
+  end
+
+  describe '.request' do
+    let(:access_token) { SecureRandom.uuid }
+
+    context 'GET method' do
+      it 'calls to API for requested URL' do
+        stub_authed_request(:get, '/v1/widgets', access_token).
+          to_return(body: '[{"id":1234,"name":"Spoon"}]')
+
+        response = Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+        expect(response).to eq [{ 'id' => 1234, 'name' => 'Spoon' }]
+      end
+
+      it 'concatenates params on URL' do
+        stub_authed_request(:get, '/v1/widgets?filter=wood', access_token).
+          to_return(body: '[{"id":5432,"name":"Chair"}]')
+
+        response =
+          Transferwise::Request.request(
+            :get,
+            '/v1/widgets',
+            { filter: 'wood'},
+            { access_token: access_token }
+          )
+        expect(response).to eq [{ 'id' => 5432, 'name' => 'Chair' }]
+      end
+
+      context 'access_token configured on Transferwise' do
+        before { allow(Transferwise).to receive(:access_token).and_return 'fallback-token' }
+
+        it 'uses token provided in headers' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '[{"id":2345,"name":"Bird"}]')
+
+          response = Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          expect(response).to eq [{ 'id' => 2345, 'name' => 'Bird' }]
+        end
+
+        it 'falls back to globally configured option' do
+          stub_authed_request(:get, '/v1/widgets', 'fallback-token').
+            to_return(body: '[{"id":3456,"name":"Hat"}]')
+
+          response = Transferwise::Request.request :get, '/v1/widgets'
+          expect(response).to eq [{ 'id' => 3456, 'name' => 'Hat' }]
+        end
+      end
+
+      context 'response is invalid JSON' do
+        it 'raises ParseError' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: 'invalid body')
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to(
+            raise_error(
+              Transferwise::ParseError,
+              'Not able to parse because of invalid response object from API: "invalid body"' \
+              ' (HTTP response code was 200)'
+            )
+          )
+        end
+      end
+
+      context 'response is a 400 bad request' do
+        it 'raises InvalidRequestError' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '{"error":"That was bad, m\'kay"}', status: 400)
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to raise_error Transferwise::InvalidRequestError, "That was bad, m'kay"
+        end
+
+        it 'handles multiple errors returned' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '{"errors":[{"message":"Error 1"},{"message":"Error 2"}]}', status: 400)
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to raise_error Transferwise::InvalidRequestError, 'Error 1, Error 2'
+        end
+      end
+
+      context 'response is a 401 unauthorized' do
+        it 'raises AuthenticationError' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '{"error":"No access for you"}', status: 401)
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to raise_error Transferwise::AuthenticationError, 'No access for you'
+        end
+      end
+
+      context 'response is a 404 not found' do
+        it 'raises InvalidRequestError' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '{"error":"No comprendo"}', status: 404)
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to raise_error Transferwise::InvalidRequestError, 'No comprendo'
+        end
+      end
+    end
+
+    context 'POST method' do
+      it 'calls to API for requested URL' do
+        stub_authed_request(:post, '/v1/widgets', access_token).
+          with(body: '{}').
+          to_return(body: '[{"id":8475,"name":"Spinner"}]')
+
+        response = Transferwise::Request.request :post, '/v1/widgets', {}, { access_token: access_token }
+        expect(response).to eq [{ 'id' => 8475, 'name' => 'Spinner' }]
+      end
+
+      it 'passes through parameters in the POST body' do
+        stub_authed_request(:post, '/v1/widgets', access_token).
+          with(body: '{"size":"large"}').
+          to_return(body: '[{"id":2938,"name":"Pen"}]')
+
+        response =
+          Transferwise::Request.request(
+            :post,
+            '/v1/widgets',
+            { size: 'large' },
+            { access_token: access_token }
+          )
+        expect(response).to eq [{ 'id' => 2938, 'name' => 'Pen' }]
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,14 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'transferwise'
+
+require 'webmock/rspec'
+
+def stub_authed_request(method, action, access_token)
+  stub_request(method, 'https://api.sandbox.transferwise.tech' + action)
+    .with(
+      headers: {
+        'Authorization' => "Bearer #{access_token}",
+        'Content-Type' => 'application/json'
+      }
+    )
+end

--- a/transferwise.gemspec
+++ b/transferwise.gemspec
@@ -27,9 +27,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency('rest-client', '>= 1.4', '< 4.0')
-  spec.add_runtime_dependency("oauth2".freeze, ["< 2.0", ">= 1.4.0"])
+  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 6.0"
+  spec.add_runtime_dependency "oauth2", ">= 1.4.0", "< 2.0"
+  spec.add_runtime_dependency "rest-client", ">= 1.4", "< 4.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.0"
 end


### PR DESCRIPTION
Many of the Transferwise API endpoints using the GET method (list and show etc) have parameters that can/must be passed through. This change modifies how the GET type requests are made, passing through the parameters such that they are included in the URI. I've added a few specs for the `Request` class too.

While I was fixing this, I noticed a few other things:
* Fixed private class method access
* Fixed assumed loading of ActiveSupport extensions
