### PR TITLE
Allow activesupport 6.0

### DIFF
--- a/transferwise.gemspec
+++ b/transferwise.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 6.0"
+  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 7"
   spec.add_runtime_dependency "oauth2", ">= 1.4.0", "< 2.0"
   spec.add_runtime_dependency "rest-client", ">= 1.4", "< 4.0"
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Looking through the [CHANGELOG for ActiveSupport 6.0.0.rc1](https://github.com/rails/rails/blob/v6.0.0.beta1/activesupport/CHANGELOG.md) it doesn't seem like there's anything breaking in there, so this PR relaxes the requirement up to 7 (next major release).