### PR TITLE
Parse response body as JSON only if it's non-empty

### DIFF
--- a/lib/transferwise/request.rb
+++ b/lib/transferwise/request.rb
@@ -48,6 +48,8 @@ module Transferwise
     private_class_method :execute_request
 
     def self.parse(response)
+      return {} if response.body.length.zero?
+
       begin
         response = JSON.parse(response.body)
       rescue JSON::ParserError

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -86,6 +86,19 @@ describe Transferwise::Request do
         end
       end
 
+      context 'response body is empty' do
+        it 'does not raise' do
+          stub_authed_request(:get, '/v1/widgets', access_token).
+            to_return(body: '')
+
+          expect do
+            Transferwise::Request.request :get, '/v1/widgets', {}, { access_token: access_token }
+          end.to_not(
+            raise_error
+          )
+        end
+      end
+
       context 'response is a 400 bad request' do
         it 'raises InvalidRequestError' do
           stub_authed_request(:get, '/v1/widgets', access_token).


### PR DESCRIPTION
An empty string is not valid JSON, and `JSON.parse` fails on such input. TransferWise (TW) had been recently returning empty bodies with their Strong Customer Response (SCA) challenge responses for a few days, presumably because headers alone are sufficient for passing SCA.

This caused the response parsing code in this library to fail, since it was expecting a valid JSON response in the body. TW fixed this on their end, but this commit should help prevent similar errors in the future.