### PR TITLE
Add support for ActiveSupport 7

### DIFF
--- a/transferwise.gemspec
+++ b/transferwise.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 7"
+  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 7.1"
   spec.add_runtime_dependency "oauth2", ">= 1.4.0", "< 2.0"
   spec.add_runtime_dependency "rest-client", ">= 1.4", "< 4.0"
   spec.add_development_dependency "bundler", "~> 2.2"


### PR DESCRIPTION
Currently, the gem is locked to ActiveSupport < 7, and therefore doesn't
allow any user to use Rails 7.

Tested on ActiveSupport 7.0.3 with no issues.