### PR TITLE
Allow active_support upto 8

### DIFF
--- a/transferwise.gemspec
+++ b/transferwise.gemspec
@@ -27,11 +27,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 7.1"
+  spec.add_runtime_dependency "activesupport", ">= 3.0.0", "< 7.3"
   spec.add_runtime_dependency "oauth2", ">= 1.4.0", "< 2.0"
   spec.add_runtime_dependency "rest-client", ">= 1.4", "< 4.0"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+
   spec.add_development_dependency "webmock", "~> 3.0"
 end


### PR DESCRIPTION
why?
We need this to resolve the dependency to bump Payments service to rails 7.1 bump